### PR TITLE
Fix issue with inserting or updating links

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -292,8 +292,6 @@ export default class RichTextEditor extends Component {
   }
 
   render() {
-    //in release build, external html files in Android can't be required, so they must be placed in the assets folder and accessed via uri
-    const pageSource = PlatformIOS ? require('./editor.html') : { uri: 'file:///android_asset/editor.html' };
     return (
       <View style={{flex: 1}}>
         <WebView
@@ -303,7 +301,7 @@ export default class RichTextEditor extends Component {
           ref={(r) => {this.webview = r}}
           onMessage={(message) => this.onMessage(message)}
           // injectedJavaScript={injectScript}
-          source={pageSource}
+          source={{ html: require('./editor').template() }}
           onLoad={() => this.init()}
         />
         {this._renderLinkModal()}

--- a/src/WebviewMessageHandler.js
+++ b/src/WebviewMessageHandler.js
@@ -57,9 +57,9 @@ export const MessageConverter = (action) => {
     case `${actions.insertOrderedList}`:
       return `zss_editor.setOrderedList();`;
     case `${actions.insertLink}`:
-      return `zss_editor.insertLink('${action.data.url}, ${action.data.title}');`;
+      return `zss_editor.insertLink('${action.data.url}', '${action.data.title}');`;
     case `${actions.updateLink}`:
-      return `zss_editor.updateLink('${action.data.url}, ${action.data.title}');`;
+      return `zss_editor.updateLink('${action.data.url}', '${action.data.title}');`;
     case `${actions.insertImage}`:
       return `zss_editor.insertImage('${action.data}');`;
     case `${actions.setSubscript}`:

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,3 +1,4 @@
+export const template = () => String.raw`
 <!DOCTYPE html>
 <html>
 	<head>
@@ -1751,3 +1752,4 @@
 		<div id="zss_editor_footer"></div>
 	</body>
 </html>
+`


### PR DESCRIPTION
It appears that inserting or updating links doesn't work because of incorrect MessageConverter parsing.

This function passes a concatenated string for the first parameter.

```
    case `${actions.insertLink}`:
      return `zss_editor.insertLink('${action.data.url}, ${action.data.title}');`;
```

And thus inserts an HTML like so:

```
<a href="https://www.test.com, Test"></a>
```

When it should have been like so:

```
<a href="https://www.test.com">Test</a>
```